### PR TITLE
Fixed ash_money docs.

### DIFF
--- a/documentation/tutorials/get-started-with-ash-money.md
+++ b/documentation/tutorials/get-started-with-ash-money.md
@@ -1,6 +1,6 @@
 # Getting Started With AshMoney
 
-## Bring in the ash_graphql dependency
+## Bring in the ash_money dependency
 
 ```elixir
 def deps()


### PR DESCRIPTION
Fixed ash money docs, there is a typo for dependency name.