### PR TITLE
Fix migrations

### DIFF
--- a/lib/ash_money/ash_postgres_extension.ex
+++ b/lib/ash_money/ash_postgres_extension.ex
@@ -3,7 +3,17 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
     @moduledoc """
     Installs the `money_with_currency` type and operators/functions for Postgres.
     """
-    use AshPostgres.CustomExtension, name: :ash_money, latest_version: 2
+    use AshPostgres.CustomExtension, name: :ash_money, latest_version: 3
+
+    def install(3) do
+      """
+      #{Money.DDL.execute_each(Money.DDL.create_money_with_currency())}
+      #{Money.DDL.execute_each(add_money_mult())}
+      #{Money.DDL.execute_each(Money.DDL.define_plus_operator())}
+      #{Money.DDL.execute_each(Money.DDL.define_minmax_functions())}
+      #{Money.DDL.execute_each(Money.DDL.define_sum_function())}
+      """
+    end
 
     def install(2) do
       """
@@ -18,6 +28,16 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       #{Money.DDL.execute_each(Money.DDL.define_plus_operator())}
       #{Money.DDL.execute_each(Money.DDL.define_minmax_functions())}
       #{Money.DDL.execute_each(Money.DDL.define_sum_function())}
+      """
+    end
+
+    def uninstall(3) do
+      """
+      #{Money.DDL.execute_each(Money.DDL.drop_sum_function())}
+      #{Money.DDL.execute_each(Money.DDL.drop_minmax_functions())}
+      #{Money.DDL.execute_each(Money.DDL.drop_plus_operator())}
+      #{Money.DDL.execute_each(remove_money_mult())}
+      #{Money.DDL.execute_each(Money.DDL.drop_money_with_currency())}
       """
     end
 


### PR DESCRIPTION
The custom extension `install` for version 2 only installed the multiplication function and operators, but didn't add anything else, not even then `money_with_currency` type, which is required for the multiplication operators and and everything else.

With a new version 3, we install the `money_with_currency` type, then everything else, and uninstall each piece in the strict opposite order.

### Contributor checklist

I didn't add tests because there weren't any already, and while having the ability to test the migrations seems interesting, the task is definitely out of the intended scope for this fix.

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
