### PR TITLE
Move create_money_with_currency to first

### DIFF
--- a/lib/ash_money/ash_postgres_extension.ex
+++ b/lib/ash_money/ash_postgres_extension.ex
@@ -39,11 +39,11 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
 
     def install(0) do
       """
+      #{Money.DDL.execute_each(Money.DDL.create_money_with_currency())}
       #{Money.DDL.execute_each(add_money_greater_than())}
       #{Money.DDL.execute_each(add_money_greater_than_or_equal())}
       #{Money.DDL.execute_each(add_money_less_than())}
       #{Money.DDL.execute_each(add_money_less_than_or_equal())}
-      #{Money.DDL.execute_each(Money.DDL.create_money_with_currency())}
       #{Money.DDL.execute_each(add_money_sub())}
       #{Money.DDL.execute_each(add_money_neg())}
       #{Money.DDL.execute_each(Money.DDL.define_plus_operator())}


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

I tried adding the latest version of `:ash_money` to a new project, and noticed a dependency issue when running the autogenerated migration. Specifically, the recently introduced `gt`, `gte`, `lt`, `lte` operators all depend on the `money_with_currency` type, which is only created after them. This PR moves it to be the first in the list, fixing this dependency issue.