### PR TITLE
improvement: add Igniter installer task

### DIFF
--- a/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
+++ b/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.AshMoney.AddToAshPostgres do
+  @moduledoc "Adds AshMoney.AshPostgresExtension to installed_extensions. Should be run as an Igniter task."
+  @shortdoc @moduledoc
+  require Igniter.Code.Common
+  use Igniter.Mix.Task
+
+  def igniter(igniter, _argv) do
+    repo = Igniter.Code.Module.module_name("Repo")
+
+    repo_path = Igniter.Code.Module.proper_location(repo)
+
+    igniter
+    # TODO: remove fixed version
+    |> Igniter.Project.Deps.add_dependency(:ex_money_sql, "~> 1.11")
+    |> Igniter.add_task("deps.get")
+    |> Igniter.update_elixir_file(repo_path, fn zipper ->
+      with {:ok, zipper} <- Igniter.Code.Module.move_to_module_using(zipper, AshPostgres.Repo),
+           {:ok, zipper} <- Igniter.Code.Module.move_to_def(zipper, :installed_extensions, 0) do
+        Igniter.Code.List.append_to_list(zipper, quote(do: AshMoney.AshPostgresExtension))
+      else
+        _ ->
+          Igniter.add_issue(
+            igniter,
+            "Unable to add AshMoney.AshPostgresExtension to installed_extensions/0 in #{inspect(repo)}"
+          )
+      end
+    end)
+    |> Igniter.add_task("ash.codegen", ["install_ash_money_extension"])
+  end
+end

--- a/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
+++ b/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.AshMoney.AddToAshPostgres do
     repo_module_name = Igniter.Code.Module.module_name("Repo")
 
     igniter
-    |> Igniter.Project.Deps.add_dependency(:ex_money_sql, "~> 1.0")
+    |> Igniter.Project.Deps.add_dep({:ex_money_sql, "~> 1.0"})
     |> Igniter.apply_and_fetch_dependencies()
     |> Igniter.Code.Module.find_and_update_module!(repo_module_name, fn zipper ->
       case Igniter.Code.Module.move_to_use(zipper, AshPostgres.Repo) do

--- a/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
+++ b/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
@@ -12,34 +12,41 @@ defmodule Mix.Tasks.AshMoney.AddToAshPostgres do
     |> Igniter.Project.Deps.add_dependency(:ex_money_sql, "~> 1.0")
     |> Igniter.apply_and_fetch_dependencies()
     |> Igniter.Code.Module.find_and_update_module!(repo_module_name, fn zipper ->
-      with {:ok, zipper} <- Igniter.Code.Module.move_to_module_using(zipper, AshPostgres.Repo) do
-        case Igniter.Code.Module.move_to_def(zipper, :installed_extensions, 0) do
-          {:ok, zipper} ->
-            case Igniter.Code.Common.move_right(zipper, &Igniter.Code.List.list?/1) do
-              {:ok, zipper} ->
-                Igniter.Code.List.append_new_to_list(
-                  zipper,
-                  AshMoney.AshPostgresExtension
-                )
+      case Igniter.Code.Module.move_to_use(zipper, AshPostgres.Repo) do
+        # discarding since we just needed to check that `use AshPostgres.Repo` exists
+        {:ok, _zipper} ->
+          case Igniter.Code.Module.move_to_def(zipper, :installed_extensions, 0) do
+            {:ok, zipper} ->
+              case Igniter.Code.Common.move_right(zipper, &Igniter.Code.List.list?/1) do
+                {:ok, zipper} ->
+                  case Igniter.Code.List.append_new_to_list(
+                         zipper,
+                         AshMoney.AshPostgresExtension
+                       ) do
+                    {:ok, zipper} ->
+                      {:ok, zipper}
 
-              :error ->
-                {:error, "installed_extensions/0 doesn't return a list"}
-            end
+                    _ ->
+                      {:error,
+                       "couldn't append `AshMoney.AshPostgresExtension` to #{inspect(repo_module_name)}.installed_extensions/0"}
+                  end
 
-          _ ->
-            Igniter.Code.Common.add_code(zipper, """
-            def installed_extensions do
-              # Add extensions here, and the migration generator will install them.
-              [AshMoney.AshPostgresExtension]
-            end
-            """)
-        end
-      else
+                :error ->
+                  {:error,
+                   "#{inspect(repo_module_name)}.installed_extensions/0 doesn't return a list"}
+              end
+
+            _ ->
+              Igniter.Code.Common.add_code(zipper, """
+              def installed_extensions do
+                # Add extensions here, and the migration generator will install them.
+                [AshMoney.AshPostgresExtension]
+              end
+              """)
+          end
+
         _ ->
-          Igniter.add_issue(
-            igniter,
-            "Unable to add AshMoney.AshPostgresExtension to installed_extensions/0 in #{inspect(repo_module_name)}"
-          )
+          {:error, "Couldn't find `use AshPostgres.Repo` in #{inspect(repo_module_name)}"}
       end
     end)
     |> Igniter.add_task("ash.codegen", ["install_ash_money_extension"])

--- a/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
+++ b/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.AshMoney.AddToAshPostgres do
-  @moduledoc "Adds AshMoney.AshPostgresExtension to installed_extensions. Should be run as an Igniter task."
+  @moduledoc "Adds AshMoney.AshPostgresExtension to installed_extensions and installs :ex_money_sql."
   @shortdoc @moduledoc
   require Igniter.Code.Common
   use Igniter.Mix.Task
@@ -10,13 +10,12 @@ defmodule Mix.Tasks.AshMoney.AddToAshPostgres do
     repo_path = Igniter.Code.Module.proper_location(repo)
 
     igniter
-    # TODO: remove fixed version
-    |> Igniter.Project.Deps.add_dependency(:ex_money_sql, "~> 1.11")
+    |> Igniter.Project.Deps.add_dependency(:ex_money_sql, "~> 1.0")
     |> Igniter.add_task("deps.get")
     |> Igniter.update_elixir_file(repo_path, fn zipper ->
       with {:ok, zipper} <- Igniter.Code.Module.move_to_module_using(zipper, AshPostgres.Repo),
            {:ok, zipper} <- Igniter.Code.Module.move_to_def(zipper, :installed_extensions, 0) do
-        Igniter.Code.List.append_to_list(zipper, quote(do: AshMoney.AshPostgresExtension))
+        Igniter.Code.List.append_new_to_list(zipper, quote(do: AshMoney.AshPostgresExtension))
       else
         _ ->
           Igniter.add_issue(

--- a/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
+++ b/lib/mix/tasks/ash_money.add_to_ash_postgres.ex
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.AshMoney.AddToAshPostgres do
   require Igniter.Code.Common
   use Igniter.Mix.Task
 
+  @impl Igniter.Mix.Task
   def igniter(igniter, _argv) do
     repo = Igniter.Code.Module.module_name("Repo")
 
@@ -11,7 +12,7 @@ defmodule Mix.Tasks.AshMoney.AddToAshPostgres do
 
     igniter
     |> Igniter.Project.Deps.add_dependency(:ex_money_sql, "~> 1.0")
-    |> Igniter.add_task("deps.get")
+    |> Igniter.apply_and_fetch_dependencies()
     |> Igniter.update_elixir_file(repo_path, fn zipper ->
       with {:ok, zipper} <- Igniter.Code.Module.move_to_module_using(zipper, AshPostgres.Repo) do
         case Igniter.Code.Module.move_to_def(zipper, :installed_extensions, 0) do
@@ -44,5 +45,12 @@ defmodule Mix.Tasks.AshMoney.AddToAshPostgres do
       end
     end)
     |> Igniter.add_task("ash.codegen", ["install_ash_money_extension"])
+  end
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _source) do
+    %Igniter.Mix.Task.Info{
+      adds_deps: [:ex_money_sql, "~> 1.0"]
+    }
   end
 end

--- a/lib/mix/tasks/ash_money.install.ex
+++ b/lib/mix/tasks/ash_money.install.ex
@@ -9,30 +9,21 @@ defmodule Mix.Tasks.AshMoney.Install do
       cldr = Igniter.Code.Module.module_name("Cldr")
 
       igniter
-      |> setup_cldr_module(cldr)
-      |> configure_cldr_config(cldr)
-    end)
-    |> configure_config()
-    |> maybe_add_to_ash_postgres()
-  end
-
-  defp setup_cldr_module(igniter, cldr) do
-    path = Igniter.Code.Module.proper_location(cldr)
-
-    if Igniter.exists?(igniter, path) do
-      igniter
-    else
-      default_cldr_contents =
+      |> Igniter.Code.Module.find_and_update_or_create_module(
+        cldr,
         """
         defmodule #{inspect(cldr)} do
           use Cldr,
             locales: ["en"],
             default_locale: "en"
         end
-        """
-
-      Igniter.create_new_elixir_file(igniter, path, default_cldr_contents)
-    end
+        """,
+        fn zipper -> {:ok, zipper} end
+      )
+      |> configure_cldr_config(cldr)
+    end)
+    |> configure_config()
+    |> maybe_add_to_ash_postgres()
   end
 
   defp configure_cldr_config(igniter, cldr) do
@@ -53,7 +44,7 @@ defmodule Mix.Tasks.AshMoney.Install do
       [:known_types],
       [AshMoney.Types.Money],
       updater: fn zipper ->
-        Igniter.Code.List.prepend_new_to_list(zipper, AshMoney.Types.Money)
+        Igniter.Code.List.append_new_to_list(zipper, AshMoney.Types.Money)
       end
     )
   end

--- a/lib/mix/tasks/ash_money.install.ex
+++ b/lib/mix/tasks/ash_money.install.ex
@@ -1,0 +1,85 @@
+defmodule Mix.Tasks.AshMoney.Install do
+  @moduledoc "Installs AshMoney. Should be run with `mix igniter.install ash_money`"
+  @shortdoc @moduledoc
+  require Igniter.Code.Common
+  use Igniter.Mix.Task
+
+  def igniter(igniter, _argv) do
+    Igniter.compose_task(igniter, "ex_cldr.install", [], fn igniter, _argv ->
+      cldr = Igniter.Code.Module.module_name("Cldr")
+
+      igniter
+      |> setup_cldr_module(cldr)
+      |> configure_cldr_config(cldr)
+    end)
+    |> configure_config()
+    |> maybe_add_to_ash_postgres()
+  end
+
+  defp setup_cldr_module(igniter, cldr) do
+    path = Igniter.Code.Module.proper_location(cldr)
+
+    if Igniter.exists?(igniter, path) do
+      igniter
+    else
+      default_cldr_contents =
+        """
+        defmodule #{inspect(cldr)} do
+          use Cldr,
+            locales: ["en"],
+            default_locale: "en"
+        end
+        """
+
+      Igniter.create_new_elixir_file(igniter, path, default_cldr_contents)
+    end
+  end
+
+  defp configure_cldr_config(igniter, cldr) do
+    Igniter.Project.Config.configure_new(
+      igniter,
+      "config.exs",
+      :ex_cldr,
+      :default_backend,
+      cldr
+    )
+  end
+
+  defp configure_config(igniter) do
+    Igniter.Project.Config.configure(
+      igniter,
+      "config.exs",
+      :ash,
+      :known_types,
+      [AshMoney.Types.Money],
+      updater: fn zipper ->
+        Igniter.Code.List.append_to_list(zipper, AshMoney.Types.Money)
+      end
+    )
+  end
+
+  defp maybe_add_to_ash_postgres(igniter) do
+    repo = Igniter.Code.Module.module_name("Repo")
+    repo_path = Igniter.Code.Module.proper_location(repo)
+
+    if Igniter.exists?(igniter, repo_path) do
+      igniter = Igniter.include_existing_elixir_file(igniter, repo_path)
+
+      zipper =
+        igniter.rewrite
+        |> Rewrite.source!(repo_path)
+        |> Rewrite.Source.get(:quoted)
+        |> Sourceror.Zipper.zip()
+
+      case Igniter.Code.Module.move_to_module_using(zipper, AshPostgres.Repo) do
+        :error ->
+          igniter
+
+        _zipper ->
+          Igniter.compose_task(igniter, "ash_money.add_to_ash_postgres")
+      end
+    else
+      igniter
+    end
+  end
+end

--- a/lib/mix/tasks/ash_money.install.ex
+++ b/lib/mix/tasks/ash_money.install.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.AshMoney.Install do
       [:known_types],
       [AshMoney.Types.Money],
       updater: fn zipper ->
-        Igniter.Code.List.append_new_to_list(zipper, quote(do: AshMoney.Types.Money))
+        Igniter.Code.List.prepend_new_to_list(zipper, AshMoney.Types.Money)
       end
     )
   end

--- a/lib/mix/tasks/ash_money.install.ex
+++ b/lib/mix/tasks/ash_money.install.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.AshMoney.Install do
       igniter,
       "config.exs",
       :ex_cldr,
-      :default_backend,
+      [:default_backend],
       cldr
     )
   end
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.AshMoney.Install do
       igniter,
       "config.exs",
       :ash,
-      :known_types,
+      [:known_types],
       [AshMoney.Types.Money],
       updater: fn zipper ->
         Igniter.Code.List.append_new_to_list(zipper, quote(do: AshMoney.Types.Money))

--- a/lib/mix/tasks/ash_money.install.ex
+++ b/lib/mix/tasks/ash_money.install.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.AshMoney.Install do
       :known_types,
       [AshMoney.Types.Money],
       updater: fn zipper ->
-        Igniter.Code.List.append_to_list(zipper, AshMoney.Types.Money)
+        Igniter.Code.List.append_new_to_list(zipper, quote(do: AshMoney.Types.Money))
       end
     )
   end

--- a/lib/mix/tasks/ash_money.install.ex
+++ b/lib/mix/tasks/ash_money.install.ex
@@ -12,11 +12,9 @@ defmodule Mix.Tasks.AshMoney.Install do
       |> Igniter.Code.Module.find_and_update_or_create_module(
         cldr_module_name,
         """
-        defmodule #{inspect(cldr_module_name)} do
-          use Cldr,
-            locales: ["en"],
-            default_locale: "en"
-        end
+        use Cldr,
+          locales: ["en"],
+          default_locale: "en"
         """,
         fn zipper -> {:ok, zipper} end
       )
@@ -54,10 +52,11 @@ defmodule Mix.Tasks.AshMoney.Install do
 
     with {:ok, {igniter, source, zipper}} <-
            Igniter.Code.Module.find_module(igniter, repo_module_name),
-         %Sourceror.Zipper{} <- Igniter.Code.Module.move_to_module_using(zipper, AshPostgres.Repo) do
+         {:ok, _zipper} <-
+           Igniter.Code.Module.move_to_module_using(zipper, AshPostgres.Repo) do
       Igniter.compose_task(igniter, "ash_money.add_to_ash_postgres")
     else
-      error ->
+      _ ->
         igniter
     end
   end

--- a/lib/mix/tasks/ash_money.install.ex
+++ b/lib/mix/tasks/ash_money.install.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.AshMoney.Install do
   defp maybe_add_to_ash_postgres(igniter) do
     repo_module_name = Igniter.Code.Module.module_name("Repo")
 
-    with {:ok, {igniter, source, zipper}} <-
+    with {:ok, {igniter, _source, zipper}} <-
            Igniter.Code.Module.find_module(igniter, repo_module_name),
          {:ok, _zipper} <-
            Igniter.Code.Module.move_to_module_using(zipper, AshPostgres.Repo) do

--- a/mix.exs
+++ b/mix.exs
@@ -116,7 +116,8 @@ defmodule AshMoney.MixProject do
       {:sobelow, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:git_ops, "~> 2.5", only: [:dev, :test]},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
-      {:mix_audit, ">= 0.0.0", only: [:dev, :test], runtime: false}
+      {:mix_audit, ">= 0.0.0", only: [:dev, :test], runtime: false},
+      {:igniter, "~> 0.2.5"}
     ]
   end
 


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

This PR adds an Igniter installer which also checks whether AshPostgres is in use, and if so, installs the `AshMoney.AshPostgresExtension` as well as `ex_money_sql`.

When testing, everything works, but I am facing an issue that seems unrelated to this installer:
```
** (UndefinedFunctionError) function AshMoney.AshPostgresExtension.extension/0 is undefined (module AshMoney.AshPostgresExtension is not available)
    AshMoney.AshPostgresExtension.extension()
    (ash_postgres 2.0.12) lib/migration_generator/migration_generator.ex:205: anonymous fn/1 in AshPostgres.MigrationGenerator.create_extension_migrations/2
    (elixir 1.17.0) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.17.0) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (ash_postgres 2.0.12) lib/migration_generator/migration_generator.ex:203: anonymous fn/2 in AshPostgres.MigrationGenerator.create_extension_migrations/2
    (elixir 1.17.0) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (ash_postgres 2.0.12) lib/migration_generator/migration_generator.ex:52: AshPostgres.MigrationGenerator.generate/2
    (mix 1.17.0) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
```

It _might_ be possible that it's actually related to it, so I'm marking the PR as draft until I figure out what's the issue.