### PR TITLE
docs: Use :money_input for input_object

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-money.md
+++ b/documentation/tutorials/getting-started-with-ash-money.md
@@ -87,7 +87,7 @@ Add the following to your schema file:
     field(:currency, non_null(:string))
   end
 
-  input_object :money do
+  input_object :money_input do
     field(:amount, non_null(:decimal))
     field(:currency, non_null(:string))
   end


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Small fix in the documentation to use the correct name for `input_object`.