### PR TITLE
fix: Fix `money_gte` function to use the correct operator

### DIFF
--- a/lib/ash_money/ash_postgres_extension.ex
+++ b/lib/ash_money/ash_postgres_extension.ex
@@ -185,14 +185,14 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       CREATE OPERATOR >= (
           leftarg = money_with_currency,
           rightarg = money_with_currency,
-          procedure = money_gt
+          procedure = money_gte
       );
 
 
       CREATE OPERATOR >= (
           leftarg = money_with_currency,
           rightarg = numeric,
-          procedure = money_gt
+          procedure = money_gte
       );
       """
     end


### PR DESCRIPTION
I'm not sure how we get this out to users that will already have the incorrect version of the function, but this definitely looks like an issue!

Would we need a `def install(4)` that installs the new version of `gte`?