### PR TITLE
Fix: Regression for `cast_stored`

### DIFF
--- a/test/ash_money_test.exs
+++ b/test/ash_money_test.exs
@@ -58,7 +58,7 @@ defmodule AshMoneyTest do
       attribute = Ash.Resource.Info.attribute(ExampleResource, :amount_with_options)
 
       {:ok, actual_output} =
-        AshMoney.Types.Money.cast_input({0, :USD}, attribute.constraints)
+        AshMoney.Types.Money.cast_input({:USD, 0}, attribute.constraints)
 
       assert actual_output == expected_output
     end
@@ -107,7 +107,7 @@ defmodule AshMoneyTest do
       attribute = Ash.Resource.Info.attribute(ExampleResource, :amount_with_options)
 
       {:ok, actual_output} =
-        AshMoney.Types.Money.cast_stored({0, "USD"}, attribute.constraints)
+        AshMoney.Types.Money.cast_stored({"USD", 0}, attribute.constraints)
 
       assert actual_output == expected_output
     end


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

- The tuple arguments were named in reverse from what `ash_money_sql`'s composite type was expecting in `cast_stored`.  The previous PR reversed them to ensure it matched.  But, it looks like the typle varialbes were just misnamed.  So, we're now passing the whole tuple value to the `composite_type.load` again.  I updated the tuple variable names from `{amount, currency}` to `{currency, amount}`, which is what `ash_money_sql`'s composite type `load` function is expecting.
