### PR TITLE
chore: Add search_path to postgres money functions

### DIFF
--- a/lib/ash_money/ash_postgres_extension.ex
+++ b/lib/ash_money/ash_postgres_extension.ex
@@ -100,6 +100,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -124,6 +125,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -158,6 +160,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -182,6 +185,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -262,6 +266,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -286,6 +291,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -320,6 +326,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -344,6 +351,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -438,6 +446,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -473,6 +482,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -517,6 +527,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;
@@ -534,6 +545,7 @@ if Code.ensure_loaded?(AshPostgres.CustomExtension) do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
       BEGIN
           RETURN money_mult(multiplicator, money);


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

https://supabase.github.io/splinter/0011_function_search_path_mutable/

> When a function does not have its search_path explicitly set, it inherits the search_path of the current session when it is invoked. This behavior can lead to several problems:
> 
> Inconsistency: The function may behave differently depending on the user's search_path settings.
> 
> Security Risks: Malicious users could potentially exploit the search_path to direct the function to use unexpected objects, such as tables or other functions, that the malicious user controls

And here's a related CVE from older versions of Postgres: https://wiki.postgresql.org/wiki/A_Guide_to_CVE-2018-1058%3A_Protect_Your_Search_Path

Reference for Ash Postgres for the same issue: https://github.com/ash-project/ash_postgres/pull/449
